### PR TITLE
Enforce typecheck in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ test-verbose: install-dev
 	$(PYTHON) -m pytest -v
 
 typecheck: install-dev
-	$(PYTHON) -m mypy ap_move_master_to_library || true
+	$(PYTHON) -m mypy ap_move_master_to_library
 
 coverage: install-dev
 	$(PYTHON) -m pytest --cov=ap_move_master_to_library --cov-report=term


### PR DESCRIPTION
- Remove || true from typecheck target to enforce type checking

Assisted-by: Claude Code (Claude Sonnet 4.5)