### PR TITLE
Use constants for calibration metadata keys and patterns

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.14"
+        python-version: "3.12"
 
     - name: Install dependencies
       run: |

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -43,6 +43,7 @@ class TestMainCLI:
         assert call_args.kwargs["debug"] is False
         assert call_args.kwargs["dryrun"] is False
         assert call_args.kwargs["no_overwrite"] is False
+        assert call_args.kwargs["quiet"] is False
 
     def test_debug_flag(self, tmp_path, mocker):
         """Test --debug flag is correctly passed."""
@@ -125,9 +126,9 @@ class TestMainCLI:
 
         main()
 
-        # quiet is used for logging setup but not passed to copy function
-        # This test verifies argparse accepts the flag
-        mock_copy.assert_called_once()
+        # Verify quiet=True is passed through to copy_calibration_frames
+        call_args = mock_copy.call_args
+        assert call_args.kwargs["quiet"] is True
 
     def test_quiet_short_flag(self, tmp_path, mocker):
         """Test -q (short form) flag works."""
@@ -147,8 +148,9 @@ class TestMainCLI:
 
         main()
 
-        # Verify -q is recognized as --quiet
-        mock_copy.assert_called_once()
+        # Verify -q maps to quiet=True in kwargs
+        call_args = mock_copy.call_args
+        assert call_args.kwargs["quiet"] is True
 
     def test_multiple_flags_combined(self, tmp_path, mocker):
         """Test --dryrun --debug --no-overwrite work together."""
@@ -179,6 +181,7 @@ class TestMainCLI:
         assert call_args.kwargs["dryrun"] is True
         assert call_args.kwargs["debug"] is True
         assert call_args.kwargs["no_overwrite"] is True
+        assert call_args.kwargs["quiet"] is False
 
     def test_all_flags_combined(self, tmp_path, mocker):
         """Test all flags work together."""
@@ -209,4 +212,5 @@ class TestMainCLI:
         call_args = mock_copy.call_args
         assert call_args.kwargs["dryrun"] is True
         assert call_args.kwargs["debug"] is True
+        assert call_args.kwargs["quiet"] is True
         assert call_args.kwargs["no_overwrite"] is True


### PR DESCRIPTION
## Summary
This PR refactors the codebase to use centralized constants for calibration metadata keys and file patterns, improving maintainability and reducing hardcoded string literals.

## Key Changes
- **Import new constants**: Added imports for `DEFAULT_CALIBRATION_PATTERNS` and `NORMALIZED_HEADER_TYPE` from `ap_common.constants`
- **Replace hardcoded metadata keys**: Changed all instances of `datum["type"]` to `datum[NORMALIZED_HEADER_TYPE]` throughout `move_calibration.py` for consistency and maintainability
- **Replace hardcoded file patterns**: Updated the file pattern list `[r".*\.xisf$", r".*\.fits$"]` to use `DEFAULT_CALIBRATION_PATTERNS` constant
- **Update filter dictionaries**: Changed filter dictionary keys from string literals to use the `NORMALIZED_HEADER_TYPE` constant
- **Improve error messages**: Updated error message to use the constant value instead of hardcoded string
- **Fix test assertions**: Enhanced test coverage to verify the `quiet` parameter is properly passed through to `copy_calibration_frames()` function
- **Update CI configuration**: Changed Python version in GitHub Actions workflow from 3.14 to 3.12

## Implementation Details
- All changes maintain backward compatibility while improving code maintainability
- The refactoring centralizes metadata key definitions, making future changes easier to manage
- Test improvements ensure the `quiet` flag is properly propagated through the function call chain

https://claude.ai/code/session_01PzCkxZ8UwCqsWsGXemCksT